### PR TITLE
Fix broken links after transfer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # soccom-d3-eg
 Example using SOCCOM open source data and D3.js to graph sensor movements.
 
-- https://adolfvonkleist.github.io/soccom-d3-eg
+- https://tlmaurer.github.io/soccom-d3-eg
 
 ## USAGE:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,7 +152,7 @@
          var xobj = new XMLHttpRequest();
          xobj.overrideMimeType("application/json");
          // Path to your file as served by your webserver
-         xobj.open ('GET', 'https://adolfvonkleist.github.io/soccom-d3-eg/data/SOCCOMtracks.json', true); 
+         xobj.open ('GET', 'https://tlmaurer.github.io/soccom-d3-eg/data/SOCCOMtracks.json', true); 
          xobj.onreadystatechange = function () {
              if (xobj.readyState == 4 && xobj.status == "200") {
                  callback (xobj.responseText);
@@ -397,7 +397,7 @@
 		}
 		
          // load and display the World
-         d3.json("https://adolfvonkleist.github.io/soccom-d3-eg/data/world-110m2.json", function(error, topology) {
+         d3.json("https://tlmaurer.github.io/soccom-d3-eg/data/world-110m2.json", function(error, topology) {
              g.selectAll("path",".graticule")
               .data(topojson.object(topology, topology.objects.countries)
                             .geometries)


### PR DESCRIPTION
This is a pull request intended to fix the broken links in the example github pages and the README.  It should make them work with the new ownership and location.